### PR TITLE
Add nteract frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ files written to `~/work` in the container remain intact on the host.
 
     docker run --rm -p 10000:8888 -e JUPYTER_ENABLE_LAB=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:9b06df75e445
 
+**Example 4: nteract** As above, this command pulls the `jupyter/datascience-notebook` image tagged `latest`
+from Docker Hub if it is not already present on the local host. It then starts an _ephemeral_
+container running a Jupyter Notebook server and exposes the server on host port 10000. The command
+mounts the current working directory on the host as `/home/jovyan/work` in the container. The server
+logs appear in the terminal. Visiting `http://<hostname>:10000/?token=<token>` in a browser loads the 
+[nteract](https://blog.nteract.io/nteract-on-jupyter-53cc2c38290d) front end, where `hostname` is the name of the computer running docker and `token` is the secret
+token printed in the console. Docker destroys the container after notebook server exit, but any
+files written to `~/work` in the container remain intact on the host.
+
+    docker run --rm -p 10000:8888 -e NTERACT=yes -v "$PWD":/home/jovyan/work jupyter/datascience-notebook:latest
+
 ## Contributing
 
 Please see the [Contributor Guide on ReadTheDocs](http://jupyter-docker-stacks.readthedocs.io/) for

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -125,7 +125,7 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
-# Install Jupyter Notebook, Lab, and Hub
+# Install Jupyter Notebook, Lab, nteract, and Hub
 # Generate a notebook server config
 # Cleanup temporary files
 # Correct permissions
@@ -134,7 +134,8 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 RUN conda install --quiet --yes \
     'notebook=6.2.0' \
     'jupyterhub=1.3.0' \
-    'jupyterlab=3.0.9' && \
+    'jupyterlab=3.0.9' \
+    'nteract_on_jupyter=2.1.3' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile.ppc64le
+++ b/base-notebook/Dockerfile.ppc64le
@@ -100,7 +100,7 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER
 
-# Install Jupyter Notebook, Lab, and Hub
+# Install Jupyter Notebook, Lab, nteract, and Hub
 # Generate a notebook server config
 # Cleanup temporary files
 # Correct permissions
@@ -109,7 +109,8 @@ RUN conda install --quiet --yes 'tini=0.18.0' && \
 RUN conda install --quiet --yes \
     'notebook=6.1.3' \
     'jupyterhub=1.1.0' \
-    'jupyterlab=2.2.5' && \
+    'jupyterlab=2.2.5' \
+    'nteract_on_jupyter=2.1.3' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/start-notebook.sh
+++ b/base-notebook/start-notebook.sh
@@ -14,6 +14,8 @@ if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
     exec /usr/local/bin/start-singleuser.sh "$@"
 elif [[ ! -z "${JUPYTER_ENABLE_LAB}" ]]; then
     . /usr/local/bin/start.sh $wrapper jupyter lab "$@"
+elif [[ ! -z "${NTERACT}" ]]; then
+    . /usr/local/bin/start.sh $wrapper jupyter nteract "$@"    
 else
     echo "WARN: Jupyter Notebook deprecation notice https://github.com/jupyter/docker-stacks#jupyter-notebook-deprecation-notice."
     . /usr/local/bin/start.sh $wrapper jupyter notebook "$@"


### PR DESCRIPTION
Adds [nteract front end](https://blog.nteract.io/nteract-on-jupyter-53cc2c38290d) to docker-stacks containers. 

Use environment variable `NTERACT=yes` to activate. Environment variable `JUPYTER_ENABLE_LAB` takes precedence, so if you have it enabled nteract will not do anything.